### PR TITLE
Bug Fix: PostgreSQL version cannot save or display name of survey. 

### DIFF
--- a/dbadapter.js
+++ b/dbadapter.js
@@ -49,6 +49,13 @@ function PostgresDBAdapter() {
       .then(callback);
   }
 
+  function changeName(id, name, callback) {
+    console.log("THIS IS THE NAME: "+name+ " ID: "+id);
+    db
+      .one("UPDATE surveys SET name = $1 WHERE id = $2 RETURNING *", [name, id])
+      .then(callback);
+  }
+
   function storeSurvey(id, json, callback) {
     db
       .one("UPDATE surveys SET json = $1 WHERE id = $2 RETURNING *", [json, id])
@@ -113,7 +120,8 @@ function PostgresDBAdapter() {
     getSurveys: getSurveys,
     deleteSurvey: deleteSurvey,
     postResults: postResults,
-    getResults: getResults
+    getResults: getResults,
+    changeName: changeName
   };
 }
 

--- a/public/editor.js
+++ b/public/editor.js
@@ -50,6 +50,7 @@ Survey.dxSurveyService.serviceUrl = "";
 var accessKey = "";
 var editor = new SurveyEditor.SurveyEditor("editor");
 var surveyId = decodeURI(getParams()["id"]);
+surveyName = decodeURI(getParams()["name"]);
 editor.loadSurvey(surveyId);
 editor.saveSurveyFunc = function(saveNo, callback) {
   var xhr = new XMLHttpRequest();
@@ -72,5 +73,4 @@ editor.isAutoSave = true;
 editor.showState = true;
 editor.showOptions = true;
 
-surveyName = surveyId;
 setSurveyName(surveyName);

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
                                 <td data-bind="text: name"></td>
                                 <td>
                                     <a class="sv_button_link" data-bind="attr: { href: 'survey.html?id=' + ko.unwrap(id) }">Run</a>
-                                    <a class="sv_button_link" data-bind="attr: { href: 'editor.html?id=' + ko.unwrap(id) }">Edit</a>
+                                    <a class="sv_button_link" data-bind="attr: { href: 'editor.html?id=' + ko.unwrap(id)+'&name='+ko.unwrap(name) }">Edit</a>
                                     <a class="sv_button_link" data-bind="attr: { href: 'results.html?id=' + ko.unwrap(id) }">Results</a>
                                     <span class="sv_button_link sv_button_delete" data-bind="click: function() { $parent.deleteSurvey(ko.unwrap(id), $parent.loadSurveys); }">Delete</span>
                                 </td>


### PR DESCRIPTION
I am not sure if this was on purpose or not - but when running the sample exercise with postgreSQL, the survey name cannot be saved, and it cannot be displayed. dbadapter.js is also missing the ChangeName function.   

In summary: Fixed bug which prevented the survey name from saving and displaying when running the sample with postgreSQL enabled